### PR TITLE
Fix for cross-origin issue

### DIFF
--- a/rt-data-viz/websocket_server.py
+++ b/rt-data-viz/websocket_server.py
@@ -2,6 +2,7 @@ import time
 import random
 import json
 import datetime
+import os
 from tornado import websocket, web, ioloop
 from datetime import timedelta
 from random import randint
@@ -55,7 +56,8 @@ class WebSocketHandler(websocket.WebSocketHandler):
 if __name__ == "__main__":
   #create new web app w/ websocket endpoint available at /websocket
   print "Starting websocket server program. Awaiting client requests to open websocket ..."
-  application = web.Application([(r'/websocket', WebSocketHandler)])
+  application = web.Application([(r'/static/(.*)', web.StaticFileHandler, {'path': os.path.dirname(__file__)}),
+                                 (r'/websocket', WebSocketHandler)])
   application.listen(8001)
   ioloop.IOLoop.instance().start()
   

--- a/rt-data-viz/websocket_server.py
+++ b/rt-data-viz/websocket_server.py
@@ -15,9 +15,8 @@ class WebSocketHandler(websocket.WebSocketHandler):
   def open(self):
     print 'Connection established.'
     #ioloop to wait for 3 seconds before starting to send data
-    ioloop.IOLoop.instance().add_timeout(datetime.       
-    timedelta(seconds=3), self.send_data)
- 
+    ioloop.IOLoop.instance().add_timeout(datetime.timedelta(seconds=3), self.send_data)
+
  #close connection
   def on_close(self):
     print 'Connection closed.'


### PR DESCRIPTION
Hi. Thanks for the nice tutorial/example. There is a small issue: recent tornado version check against request origin, thus your original code (requests coming from another webserver on port 3000) failed with a 403. A solution could be to implement the check_origin method and return True in all cases, but since we already have the tornado webserver running, there is no point in running another. This patch will serve the module directory as static files, so all you need to do in run the websocket_server.py and access http://localhost:8001/static/index.html
